### PR TITLE
computing permutation importance for each run n with 10 permutations

### DIFF
--- a/copro/scripts/copro_runner.py
+++ b/copro/scripts/copro_runner.py
@@ -63,11 +63,19 @@ def cli(cfg: click.Path, cores: int, verbose: int):
 
     # - fit-transform on scaler to be used later during projections
 
-    _, out_y_df, out_dict = ModelWorkflow.run(
+    _, out_y_df, out_perm_importances_df, out_dict = ModelWorkflow.run(
         config_REF.getint("machine_learning", "n_runs"), tune_hyperparameters=True
     )
 
-    # - save output dictionary to csv-file
+    # - save output to files
+    out_perm_importances_df.columns = [
+        key
+        for key in XY_class.XY_dict
+        if key not in ["poly_ID", "poly_geometry", "conflict"]
+    ]
+    out_perm_importances_df.to_parquet(
+        os.path.join(out_dir_REF, "perm_importances.parquet")
+    )
     io.save_to_csv(out_dict, out_dir_REF, "evaluation_metrics")
     io.save_to_npy(out_y_df, out_dir_REF, "raw_output_data")
 

--- a/copro/settings.py
+++ b/copro/settings.py
@@ -106,7 +106,6 @@ def _collect_simulation_settings(config: RawConfigParser, root_dir: click.Path) 
         each_val = os.path.abspath(os.path.join(root_dir, each_val))
 
         # parse each config-file specified
-        click.echo(f"Parsing settings from file {each_val}.")
         each_config = _parse_settings(each_val)
 
         # update the output dictionary with key and config-object

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ mypy
 nbsphinx_link==1.3.0
 pre-commit
 prospector>=1.9.0
+pyarrow==16.0.0
 pydata-sphinx-theme==0.15.2
 pylint
 rasterstats==0.19.0

--- a/tests/test_conflict.py
+++ b/tests/test_conflict.py
@@ -33,14 +33,3 @@ def test_split_conflict_geom_data():
     X_false = np.where(np.equal(X_in, X_out) == False)[0]
 
     assert X_false.size == 0
-
-
-def test_get_poly_geometry():
-
-    gdf = gpd.read_file(gpd.datasets.get_path("naturalearth_lowres"))
-
-    config = create_fake_config()
-
-    list_geometry = conflict.get_poly_geometry(gdf, config)
-
-    assert len(gdf) == len(list_geometry)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -13,21 +13,3 @@ def create_fake_config():
     config.set("general", "verbose", str(False))
 
     return config
-
-
-def test_split_XY_data():
-
-    config = create_fake_config()
-
-    X_arr = [[1, 2], [3, 4], [1, 2], [5, 6]]
-    y_arr = [1, 0, 0, 1]
-
-    XY_in = np.column_stack((X_arr, y_arr))
-
-    X, Y = xydata.split_XY_data(XY_in, config)
-
-    XY_out = np.column_stack((X, Y))
-
-    XY_false = np.where(np.equal(XY_in, XY_out) == False)[0]
-
-    assert XY_false.size == 0


### PR DESCRIPTION
Per model run `n`, features are permuted 10 times to compute permutation importances.
All `n` times 10 permutation importances are concatenated and saved as parquet-file to the _REF output directory.